### PR TITLE
Fix for Jest

### DIFF
--- a/mobile-center-crashes/Crashes.js
+++ b/mobile-center-crashes/Crashes.js
@@ -66,7 +66,7 @@ let Crashes = {
 };
 
 // Android does not have "isDebuggerAttached" method
-if (Crashes && RNCrashes.isDebuggerAttached) {
+if (Crashes && RNCrashes && RNCrashes.isDebuggerAttached) {
     Crashes = Object.assign({
         async isDebuggerAttached() {
             return await RNCrashes.isDebuggerAttached();


### PR DESCRIPTION
In the jest environment, RNCrashes does not exist, as it is initialized from NativeModules, which in turn does not exist. Hence, checking for RNCrashes first.