### PR TITLE
Updated Crashes.js and Analytics.js to not use

### DIFF
--- a/TestApp/__tests__/index.android.js
+++ b/TestApp/__tests__/index.android.js
@@ -1,6 +1,6 @@
 import 'react-native';
 import React from 'react';
-import Index from '../index.android.js';
+import Index from '../index.js';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/TestApp/__tests__/index.ios.js
+++ b/TestApp/__tests__/index.ios.js
@@ -1,6 +1,6 @@
 import 'react-native';
 import React from 'react';
-import Index from '../index.ios.js';
+import Index from '../index.js';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/TestApp/index.js
+++ b/TestApp/index.js
@@ -28,7 +28,7 @@ data["undefd"] = undefined;
 data["recursive"] = data;
 data["function"] = function () { console.log(arguments);};
 
-class TestApp extends Component {
+export default class TestApp extends Component {
   constructor() {
     super();
     this.state = {

--- a/mobile-center-analytics/Analytics.js
+++ b/mobile-center-analytics/Analytics.js
@@ -1,16 +1,19 @@
 let RNAnalytics = require("react-native").NativeModules.RNAnalytics;
 
 module.exports = {
-    async trackEvent(eventName, properties) {
-        await RNAnalytics.trackEvent(eventName, sanitizeProperties(properties));
+    // async - returns a Promise
+    trackEvent(eventName, properties) {
+        return RNAnalytics.trackEvent(eventName, sanitizeProperties(properties));
     },
 
-    async getEnabled() {
-        return await RNAnalytics.getEnabled();
+    // async - returns a Promise
+    getEnabled() {
+        return RNAnalytics.getEnabled();
     },
 
-    async setEnabled(enabled) {
-        return await RNAnalytics.setEnabled(enabled);
+    // async - returns a Promise
+    setEnabled(enabled) {
+        return RNAnalytics.setEnabled(enabled);
     }
 
     /*

--- a/mobile-center-crashes/Crashes.js
+++ b/mobile-center-crashes/Crashes.js
@@ -1,30 +1,34 @@
-import { DeviceEventEmitter, NativeModules } from 'react-native';
-const RNCrashes = NativeModules.RNCrashes;
+let ReactNative = require('react-native');
+const RNCrashes = ReactNative.NativeModules.RNCrashes;
 
 const willSendEvent = "MobileCenterErrorReportOnBeforeSending";
 const sendDidSucceed = "MobileCenterErrorReportOnSendingSucceeded";
 const sendDidFail = "MobileCenterErrorReportOnSendingFailed";
 
 let Crashes = {
-    // Functions
-    async generateTestCrash() {
-        return await RNCrashes.generateTestCrash();
+    // async - returns a Promise
+    generateTestCrash() {
+        return RNCrashes.generateTestCrash();
     },
 
-    async hasCrashedInLastSession() {
-        return await RNCrashes.hasCrashedInLastSession();
+    // async - returns a Promise
+    hasCrashedInLastSession() {
+        return RNCrashes.hasCrashedInLastSession();
     },
 
-    async lastSessionCrashReport() {
-        return await RNCrashes.lastSessionCrashReport();
+    // async - returns a Promise
+    lastSessionCrashReport() {
+        return RNCrashes.lastSessionCrashReport();
     },
 
-    async isEnabled() {
-        return await RNCrashes.isEnabled();
+    // async - returns a Promise
+    isEnabled() {
+        return RNCrashes.isEnabled();
     },
 
-    async setEnabled(shouldEnable) {
-        await RNCrashes.setEnabled(shouldEnable);
+    // async - returns a Promise
+    setEnabled(shouldEnable) {
+        return RNCrashes.setEnabled(shouldEnable);
     },
 
     process(callback) {
@@ -54,13 +58,13 @@ let Crashes = {
 
     addEventListener(listenerMap) {
         if (listenerMap.willSendCrash) {
-            DeviceEventEmitter.addListener(willSendEvent, listenerMap.willSendCrash);
+            ReactNative.DeviceEventEmitter.addListener(willSendEvent, listenerMap.willSendCrash);
         }
         if (listenerMap.didSendCrash) {
-            DeviceEventEmitter.addListener(sendDidSucceed, listenerMap.didSendCrash);
+            ReactNative.DeviceEventEmitter.addListener(sendDidSucceed, listenerMap.didSendCrash);
         }
         if (listenerMap.failedSendingCrash) {
-            DeviceEventEmitter.addListener(sendDidFail, listenerMap.failedSendingCrash);
+            ReactNative.DeviceEventEmitter.addListener(sendDidFail, listenerMap.failedSendingCrash);
         }
     }
 };
@@ -68,8 +72,9 @@ let Crashes = {
 // Android does not have "isDebuggerAttached" method
 if (Crashes && RNCrashes && RNCrashes.isDebuggerAttached) {
     Crashes = Object.assign({
-        async isDebuggerAttached() {
-            return await RNCrashes.isDebuggerAttached();
+        // async - returns a Promise
+        isDebuggerAttached() {
+            return RNCrashes.isDebuggerAttached();
         },
     }, Crashes);
 }


### PR DESCRIPTION
ES2015 features (async/await and import), to workaround issue of Babel not being invoked by default when running Jest tests