### PR TITLE
Bump version numbers for new SDK release, that includes push

### DIFF
--- a/RNMobileCenter.podspec
+++ b/RNMobileCenter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = 'RNMobileCenter'
-  s.version           = '0.4.0'
+  s.version           = '0.5.0'
   s.summary           = 'React Native plugin for Mobile Center'
   s.license           = { :type => 'MIT',  :file => 'RNMobileCenter/LICENSE' }
   s.homepage          = 'https://mobile.azure.com'
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 
   s.vendored_frameworks = 'RNMobileCenter/RNMobileCenter.framework'
 
-  s.dependency 'MobileCenter', '~> 0.6.0'
+  s.dependency 'MobileCenter', '~> 0.9.0'
 end

--- a/RNMobileCenter/android/build.gradle
+++ b/RNMobileCenter/android/build.gradle
@@ -28,8 +28,8 @@ allprojects {
         defaultConfig {
             minSdkVersion 16
             targetSdkVersion 22
-            versionCode 4
-            versionName "0.3.0"
+            versionCode 5
+            versionName "0.5.0"
             group groupId
             version versionName
             buildConfigField 'String', "SDK_NAME", "\"mobilecenter.react-native\""
@@ -110,7 +110,7 @@ repositories {
 
 dependencies {
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.microsoft.azure.mobile:mobile-center:0.6.+'
+    compile 'com.microsoft.azure.mobile:mobile-center:0.9.+'
 }
 
 artifacts {

--- a/RNMobileCenter/ios/RNMobileCenter/RNMobileCenter.m
+++ b/RNMobileCenter/ios/RNMobileCenter/RNMobileCenter.m
@@ -28,7 +28,7 @@ static MSWrapperSdk * wrapperSdk;
   if (![MSMobileCenter isConfigured]) {
       MSWrapperSdk * wrapperSdk =
         [[MSWrapperSdk alloc]
-            initWithWrapperSdkVersion:@"0.1.0"
+            initWithWrapperSdkVersion:@"0.5.0"
             wrapperSdkName:@"mobilecenter.react-native"
             liveUpdateReleaseLabel:nil
             liveUpdateDeploymentKey:nil

--- a/mobile-center-analytics/android/build.gradle
+++ b/mobile-center-analytics/android/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 3
-        versionName "0.3.0"
+        versionCode 5
+        versionName "0.5.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -19,7 +19,7 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:0.19.+'
-    compile 'com.microsoft.azure.mobile:mobile-center-analytics:0.6.+'
+    compile 'com.microsoft.azure.mobile:mobile-center-analytics:0.9.+'
     // compile (name:'RNMobileCenter', ext:'aar')
-    compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.3.+'
+    compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.5.+'
 }

--- a/mobile-center-analytics/package.json
+++ b/mobile-center-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-center-analytics",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "React Native plugin for Mobile Center Analytics",
   "main": "Analytics.js",
   "repository": {

--- a/mobile-center-analytics/scripts/postlink.js
+++ b/mobile-center-analytics/scripts/postlink.js
@@ -16,8 +16,8 @@ return rnpmlink.ios.initMobileCenterConfig().then(function (file) {
 }).then(function (file) {
     console.log('Added code to initialize iOS Crashes SDK in ' + file);
     return rnpmlink.ios.addPodDeps([
-        { pod: 'MobileCenter', version: '0.6.0' },
-        { pod: 'RNMobileCenter', version: '0.4.0' }
+        { pod: 'MobileCenter', version: '0.9.0' },
+        { pod: 'RNMobileCenter', version: '0.5.0' }
     ]).catch(function (e) {
         console.log(`
             Could not install dependencies using CocoaPods.

--- a/mobile-center-crashes/android/build.gradle
+++ b/mobile-center-crashes/android/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 3
-        versionName "0.3.0"
+        versionCode 5
+        versionName "0.5.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -19,7 +19,7 @@ dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
     compile 'com.facebook.react:react-native:0.19.+'
-    compile 'com.microsoft.azure.mobile:mobile-center-crashes:0.6.+'
+    compile 'com.microsoft.azure.mobile:mobile-center-crashes:0.9.+'
     // compile (name:'RNMobileCenter', ext:'aar')
-    compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.3.+'
+    compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.5.+'
 }

--- a/mobile-center-crashes/package.json
+++ b/mobile-center-crashes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-center-crashes",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "React Native plugin for Mobile Center Crashes",
   "main": "Crashes.js",
   "repository": {

--- a/mobile-center-crashes/scripts/postlink.js
+++ b/mobile-center-crashes/scripts/postlink.js
@@ -16,8 +16,8 @@ return rnpmlink.ios.initMobileCenterConfig().then(function (file) {
 }).then(function (file) {
     console.log('Added code to initialize iOS Crashes SDK in ' + file);
     return rnpmlink.ios.addPodDeps([
-        { pod: 'MobileCenter', version: '0.6.0' },
-        { pod: 'RNMobileCenter', version: '0.4.0' }
+        { pod: 'MobileCenter', version: '0.9.0' },
+        { pod: 'RNMobileCenter', version: '0.5.0' }
     ]).catch(function (e) {
         console.log(`
             Could not install dependencies using CocoaPods.

--- a/mobile-center-push/android/build.gradle
+++ b/mobile-center-push/android/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1
-        versionName "0.1.0"
+        versionCode 5
+        versionName "0.5.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
@@ -21,5 +21,5 @@ dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
     compile 'com.microsoft.azure.mobile:mobile-center-push:0.9.+'
     // compile (name:'RNMobileCenter', ext:'aar')
-    compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.4.+'
+    compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.5.+'
 }

--- a/mobile-center-push/package.json
+++ b/mobile-center-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-center-push",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "React Native plugin for Mobile Center Push",
   "main": "Push.js",
   "repository": {

--- a/mobile-center-push/scripts/postlink.js
+++ b/mobile-center-push/scripts/postlink.js
@@ -17,7 +17,7 @@ return rnpmlink.ios.initMobileCenterConfig().then(function (file) {
     console.log('Added code to initialize iOS Crashes SDK in ' + file);
     return rnpmlink.ios.addPodDeps([
         { pod: 'MobileCenter', version: '0.9.0' },
-        { pod: 'RNMobileCenter', version: '0.4.0' }
+        { pod: 'RNMobileCenter', version: '0.5.0' }
     ]).catch(function (e) {
         console.log(`
             Could not install dependencies using CocoaPods.

--- a/release-steps.txt
+++ b/release-steps.txt
@@ -1,5 +1,16 @@
 **** Bumping version numbers, for components that change (or whose static dependencies change) ***
 
+  I'm trying to follow this convention now for version numbers, to make things a simpler and have an overall RN SDK
+  version number when we can:
+  - If just one component changes (and API not backwards compatible), bump the version number for it.
+    For instance, if 0.5.0 is prevailing version in the RN SDK and Android (but not iOS) native SDK gets updated, we can
+    update Android components in the RN SDK to 0.6.0.
+  - If several components change (and API not backwards compatible) then bump the version number for all, skipping component versions
+    if necessary to have a consistent prevailing version for the RN SDK.
+    For instance, in the scenario above, if later the both iOS and Android native SDKs change, then bump
+    the version number for Android components from 0.6 to 0.7 and for iOS components from 0.5 to 0.7 (skipping 0.6).
+    0.7 becomes the new prevailing version number for the RN SDK.
+
   RNMobileCenter Android
     mobile-center-sdk-react-native/RNMobileCenter/android/build.gradle
       Add 1 to versionCode (it's just a counter that need be unique)
@@ -24,6 +35,10 @@
     mobile-center-analytics/package.json
     mobile-center-analytics/scripts/postlink.js (for iOS pod dependencies)
     mobile-center-analytics/android/build.gradle (dependences at bottom)
+
+    mobile-center-push/package.json
+    mobile-center-push/scripts/postlink.js (for iOS pod dependencies)
+    mobile-center-push/android/build.gradle (versionCode, versionName, and dependences at bottom)
 
     mobile-center-link-script/package.json
 


### PR DESCRIPTION
Now the React Native SDK has overall prevailing version 0.5.0,
so 0.5.0 is used as the version of most components