### PR TITLE
Fix ios link when using create-react-native-app then ejecting without dash or renaming

### DIFF
--- a/mobile-center-link-scripts/src/ios/MobileCenterConfig.js
+++ b/mobile-center-link-scripts/src/ios/MobileCenterConfig.js
@@ -40,7 +40,15 @@ function addConfigToProject(file) {
     return new Promise(function (resolve, reject) {
         debug(`Trying to add ${file} to XCode project`);
 
-        var globString = `**/${(pjson && pjson.name ? pjson.name : '*')}.xcodeproj/project.pbxproj`
+        var globString;
+        if (pjson && pjson.name) {
+            globString = `**/${(pjson.name.replace(/-/g, ''))}`;
+        }
+        else {
+            globString = `ios/*`;
+        }
+        globString += '.xcodeproj/project.pbxproj';
+
         var projectPaths = glob.sync(globString, { ignore: 'node_modules/**' });
 
         if (projectPaths.length !== 1) {
@@ -66,7 +74,7 @@ function addConfigToProject(file) {
                 var relativeFilePath = path.relative(path.resolve(projectPath, '../..'), file);
                 var plistPbxFile = project.addFile(relativeFilePath, project.getFirstProject().firstProject.mainGroup);
                 if (plistPbxFile === null) {
-                    debug(`Looks like ${file} was already added to ${this.projectPath}`);
+                    debug(`Looks like ${file} was already added to ${projectPath}`);
                     resolve(file);
                     return;
                 }

--- a/mobile-center-link-scripts/src/ios/MobileCenterConfig.js
+++ b/mobile-center-link-scripts/src/ios/MobileCenterConfig.js
@@ -40,15 +40,7 @@ function addConfigToProject(file) {
     return new Promise(function (resolve, reject) {
         debug(`Trying to add ${file} to XCode project`);
 
-        var globString;
-        if (pjson && pjson.name) {
-            globString = `**/${(pjson.name.replace(/-/g, ''))}`;
-        }
-        else {
-            globString = `ios/*`;
-        }
-        globString += '.xcodeproj/project.pbxproj';
-
+        var globString = 'ios/*.xcodeproj/project.pbxproj'
         var projectPaths = glob.sync(globString, { ignore: 'node_modules/**' });
 
         if (projectPaths.length !== 1) {


### PR DESCRIPTION
create-react-native-app name-with-dashes
yarn run eject
react-native-link

Without this patch it would not find the xcodeproject folder in ios/namewithdashes