### PR TITLE
[ios-native-module] Fix hasCrashedInLastSession and lastSessionCrashReport

### DIFF
--- a/mobile-center-crashes/ios/RNCrashes/RNCrashes.m
+++ b/mobile-center-crashes/ios/RNCrashes/RNCrashes.m
@@ -105,12 +105,7 @@ RCT_EXPORT_METHOD(lastSessionCrashReport:(RCTPromiseResolveBlock)resolve
 {
     void (^fetchLastSessionCrashReport)() = ^void() {
         MSErrorReport *report = [MSCrashes lastSessionCrashReport];
-        NSDictionary *jsonReport = convertReportToJS(report);
-        if (jsonReport && [jsonReport count] > 0) {
-            resolve(convertReportToJS(report));
-        } else {
-            resolve(nil);
-        }
+        resolve(convertReportToJS(report));
     };
     dispatch_async(dispatch_get_main_queue(), fetchLastSessionCrashReport);
 }

--- a/mobile-center-crashes/ios/RNCrashes/RNCrashes.m
+++ b/mobile-center-crashes/ios/RNCrashes/RNCrashes.m
@@ -95,7 +95,7 @@ RCT_EXPORT_METHOD(hasCrashedInLastSession:(RCTPromiseResolveBlock)resolve
 {
     void (^fetchHasCrashedInLastSession)() = ^void() {
         MSErrorReport *report = [MSCrashes lastSessionCrashReport];
-        resolve(@(report != nil));
+        resolve(report != nil ? @YES : @NO);
     };
     dispatch_async(dispatch_get_main_queue(), fetchHasCrashedInLastSession);
 }
@@ -105,7 +105,12 @@ RCT_EXPORT_METHOD(lastSessionCrashReport:(RCTPromiseResolveBlock)resolve
 {
     void (^fetchLastSessionCrashReport)() = ^void() {
         MSErrorReport *report = [MSCrashes lastSessionCrashReport];
-        resolve(convertReportToJS(report));
+        NSDictionary *jsonReport = convertReportToJS(report);
+        if (jsonReport && [jsonReport count] > 0) {
+            resolve(convertReportToJS(report));
+        } else {
+            resolve(nil);
+        }
     };
     dispatch_async(dispatch_get_main_queue(), fetchLastSessionCrashReport);
 }

--- a/mobile-center-crashes/ios/RNCrashes/RNCrashesUtils.m
+++ b/mobile-center-crashes/ios/RNCrashes/RNCrashesUtils.m
@@ -85,7 +85,7 @@ static NSDictionary *serializeDeviceToDictionary(MSDevice* device) {
 
 NSDictionary* convertReportToJS(MSErrorReport* report) {
     if (report == nil) {
-        return @{};
+        return nil;
     }
     NSMutableDictionary * dict = [[NSMutableDictionary alloc] init];
     NSString * identifier = [report incidentIdentifier];


### PR DESCRIPTION
On Android `hasCrashedInLastSession` returns `false` or `true` And `getLastSessionCrashReport` returns null or the report object. iOS returns 0 / 1 instead of a boolean for `hasCrashedInLastSession` and returns an empty JSON object instead of null for `getLastSessionCrashReport`.

Android behavior is the correct one, this PR fixes the iOS implementation