### PR TITLE
Remove inclusion of RN 0.19 from build dependencies

### DIFF
--- a/mobile-center-analytics/android/build.gradle
+++ b/mobile-center-analytics/android/build.gradle
@@ -18,7 +18,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.azure.mobile:mobile-center-analytics:0.11.+'
 
     //compile project(':RNMobileCenterShared')   // For testing with TestApp

--- a/mobile-center-crashes/android/build.gradle
+++ b/mobile-center-crashes/android/build.gradle
@@ -18,7 +18,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.azure.mobile:mobile-center-crashes:0.11.+'
 
     //compile project(':RNMobileCenterShared')   // For testing with TestApp

--- a/mobile-center-push/android/build.gradle
+++ b/mobile-center-push/android/build.gradle
@@ -18,7 +18,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.azure.mobile:mobile-center-push:0.11.+'
 
     //compile project(':RNMobileCenterShared')   // For testing with TestApp

--- a/mobile-center/android/build.gradle
+++ b/mobile-center/android/build.gradle
@@ -18,7 +18,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:23.0.1'
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.microsoft.azure.mobile:mobile-center:0.11.+'
 
     //compile project(':RNMobileCenterShared')   // For testing with TestApp


### PR DESCRIPTION
This change removes the reference to React Native 0.19 from the gradle dependencies. Including `0.19.+` causes the dependency resolver to include version 0.19.1 from maven central in addition to the version of React Native installed locally via npm. While this does not necessarily create a runtime issue, it causes extra downloads and pollutes the library list in Android Studio.
The convention in other React Native libraries, such as "react-native-code-push" is to just use the `+` alone:
https://github.com/Microsoft/react-native-code-push/blob/master/android/app/build.gradle
