### PR TITLE
Add very concise readme for each npm package to work around an issue of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Mobile Center SDK uses a modular architecture so you can use any or all of t
 
 2. **Mobile Center Crashes**: Mobile Center Crashes will automatically generate a crash log every time your app crashes. The log is first written to the device's storage and when the user starts the app again, the crash report will be sent to Mobile Center. Collecting crashes works for both beta and live apps, i.e. those submitted to the App Store. Crash logs contain valuable information for you to help fix the crash.
 
-3. **Mobile Center Push**: Mobile Center Push enables you to send push notifications to users of your app from the Mobile Center portal. We use APNS for iOS apps and FCM for Android. You can also segment your user base based on a set of properties and send them targeted notifications.
+3. **Mobile Center Push**: Mobile Center Push enables you to send push notifications to users of your app from the Mobile Center portal. We use APNs for iOS apps and FCM for Android. You can also segment your user base based on a set of properties and send them targeted notifications.
 
 ## 1. Get started
 It is super easy to use Mobile Center. Have a look at our [get started documentation](https://docs.microsoft.com/en-us/mobile-center/sdk/getting-started/react-native) and onboard your app within minutes. Our [detailed documentation](https://docs.microsoft.com/en-us/mobile-center/sdk/) is available as well.

--- a/mobile-center-analytics/README.md
+++ b/mobile-center-analytics/README.md
@@ -1,0 +1,6 @@
+# Mobile Center SDK for React Native
+## Mobile Center Analytics Module
+
+Mobile Center is mission control for mobile apps. Get faster release cycles, higher-quality apps, and the insights to build what users want.
+
+Mobile Center Analytics helps you understand user behavior and customer engagement to improve your app. The SDK automatically captures session count, device properties like model, OS version, etc. You can define your own custom events to measure things that matter to you. All the information captured is available in the Mobile Center portal for you to analyze the data.

--- a/mobile-center-analytics/package.json
+++ b/mobile-center-analytics/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native#readme",
+  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/mobile-center-analytics#readme",
   "dependencies": {
     "mobile-center": "0.8.1"
   },

--- a/mobile-center-analytics/package.json
+++ b/mobile-center-analytics/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/mobile-center-analytics#readme",
+  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/blob/master/mobile-center-analytics/README.md",
   "dependencies": {
     "mobile-center": "0.8.1"
   },

--- a/mobile-center-crashes/README.md
+++ b/mobile-center-crashes/README.md
@@ -1,0 +1,6 @@
+# Mobile Center SDK for React Native
+## Mobile Center Crashes Module
+
+Mobile Center is mission control for mobile apps. Get faster release cycles, higher-quality apps, and the insights to build what users want.
+
+Mobile Center Crashes will automatically generate a crash log every time your app crashes. The log is first written to the device's storage and when the user starts the app again, the crash report will be sent to Mobile Center. Collecting crashes works for both beta and live apps, i.e. those submitted to the App Store. Crash logs contain valuable information for you to help fix the crash.

--- a/mobile-center-crashes/package.json
+++ b/mobile-center-crashes/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native#readme",
+  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/mobile-center-crashes#readme",
   "dependencies": {
     "mobile-center": "0.8.1"
   },

--- a/mobile-center-crashes/package.json
+++ b/mobile-center-crashes/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/mobile-center-crashes#readme",
+  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/blob/master/mobile-center-crashes/README.md",
   "dependencies": {
     "mobile-center": "0.8.1"
   },

--- a/mobile-center-push/READMD.md
+++ b/mobile-center-push/READMD.md
@@ -1,0 +1,6 @@
+# Mobile Center SDK for React Native
+## Mobile Center Push Module
+
+Mobile Center is mission control for mobile apps. Get faster release cycles, higher-quality apps, and the insights to build what users want.
+
+Mobile Center Push enables you to send push notifications to users of your app from the Mobile Center portal. We use APNs for iOS apps and FCM for Android. You can also segment your user base based on a set of properties and send them targeted notifications.

--- a/mobile-center-push/package.json
+++ b/mobile-center-push/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native#readme",
+  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/mobile-center-push#readme",
   "dependencies": {
     "mobile-center": "0.8.1"
   },

--- a/mobile-center-push/package.json
+++ b/mobile-center-push/package.json
@@ -17,7 +17,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/mobile-center-push#readme",
+  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/blob/master/mobile-center-push/README.md",
   "dependencies": {
     "mobile-center": "0.8.1"
   },

--- a/mobile-center/README.md
+++ b/mobile-center/README.md
@@ -1,0 +1,3 @@
+# Mobile Center SDK for React Native
+
+Mobile Center is mission control for mobile apps. Get faster release cycles, higher-quality apps, and the insights to build what users want.

--- a/mobile-center/package.json
+++ b/mobile-center/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/microsoft/mobile-center-sdk-react-native/mobile-center#readme",
+  "homepage": "https://github.com/Microsoft/mobile-center-sdk-react-native/blob/master/mobile-center/README.md",
   "dependencies": {
     "mobile-center-link-scripts": "0.8.1"
   },

--- a/mobile-center/package.json
+++ b/mobile-center/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/microsoft/mobile-center-sdk-react-native/issues"
   },
-  "homepage": "https://github.com/microsoft/mobile-center-sdk-react-native#readme",
+  "homepage": "https://github.com/microsoft/mobile-center-sdk-react-native/mobile-center#readme",
   "dependencies": {
     "mobile-center-link-scripts": "0.8.1"
   },


### PR DESCRIPTION
Fixing #10 

Our React Native npm packages do NOT have any readme information due to [a bug of www.npmjs.com](https://github.com/npm/registry/issues/120#issuecomment-320768152). Basically npm only displays readme.md in the root level directory of the repository, but https://github.com/Microsoft/mobile-center-sdk-react-native repo has each module in its own subdirectory. So we need to add readme for each module (core / Analytics / Crashes / Push) in order for them to show up on www.npmjs.com.

<img width="556" alt="screen shot 2017-08-11 at 5 30 44 pm" src="https://user-images.githubusercontent.com/4079255/29236086-e6fb968c-7eba-11e7-8fe2-61798afdb19d.png">


