### PR TITLE
Create a script for bumping wrapper sdk version

### DIFF
--- a/DemoApp/.vscode/launch.json
+++ b/DemoApp/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible Node.js debug attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/TestApp/.vscode/launch.json
+++ b/TestApp/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-    // Use IntelliSense to learn about possible Node.js debug attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {

--- a/mobile-center-crashes/package.json
+++ b/mobile-center-crashes/package.json
@@ -49,5 +49,4 @@
       "postlink": "node node_modules/mobile-center-crashes/scripts/postlink"
     }
   }
-
 }

--- a/release-steps.txt
+++ b/release-steps.txt
@@ -11,40 +11,14 @@
     the version number for Android components from 0.6 to 0.7 and for iOS components from 0.5 to 0.7 (skipping 0.6).
     0.7 becomes the new prevailing version number for the RN SDK.
 
-  RNMobileCenterShared Android
-    RNMobileCenterShared/android/build.gradle
-      Add 1 to versionCode (it's just a counter that need be unique)
-      Bump the version in versionName
-      Ensure com.microsoft.azure.mobile:mobile-center dependency version (at the bottom) is correct
+  First, make sure the iOS/Android native sdk version has been updated. 
 
-  RNMobileCenterShared iOS
-    RNMobileCenterShared/Products/RNMobileCenterShared.podspec
-      Bump the version num s.version
-      Ensure s.dependency 'MobileCenter' dependency version (at the bottom) is correct
-    RNMobileCenterShared.m
-      Update the version number used for `initWithWrapperSdkVersion:`.  That should match s.version in
-      RNMobileCenterShared.podspec (and for Android the wrapper SDK version comes from the version number
-      in build.gradle)
-
-
-  NPM modules
-    mobile-center/package.json
-    mobile-center/scripts/postlink.js (for iOS pod dependencies)
-    mobile-center/android/build.gradle (versionCode, versionName, and dependences at bottom)
-
-    mobile-center-crashes/package.json
-    mobile-center-crashes/scripts/postlink.js (for iOS pod dependencies)
-    mobile-center-crashes/android/build.gradle (versionCode, versionName, and dependences at bottom)
-
-    mobile-center-analytics/package.json
-    mobile-center-analytics/scripts/postlink.js (for iOS pod dependencies)
-    mobile-center-analytics/android/build.gradle (versionCode, versionName, and dependences at bottom)
-
-    mobile-center-push/package.json
-    mobile-center-push/scripts/postlink.js (for iOS pod dependencies)
-    mobile-center-push/android/build.gradle (versionCode, versionName, and dependences at bottom)
-
-    mobile-center-link-script/package.json
+  Then, run the follow command to bump the wrapper sdk version:
+    bash ./scripts/bump-wrapper-sdk-version.sh --oldWrapperSdkVersion=<old_version> --newWrapperSdkVersion=<new_version> --oldAndroidVersionCode=<old_version> --newAndroidVersionCode=<new_version>
+  
+  Note that "oldWrapperSdkVersion" is the latest version of Mobile Center React Native SDK that we release (https://github.com/Microsoft/mobile-center-sdk-react-native/releases),
+  and "oldAndroidVersionCode" is "versionCode" in the ./mobile-center/android/build.gradle file. For example, when we want to release v0.8.2 of this SDK, the bash command to run should be:
+    bash ./scripts/bump-wrapper-sdk-version.sh --oldWrapperSdkVersion=0.8.1 --newWrapperSdkVersion=0.8.2 --oldAndroidVersionCode=9 --newAndroidVersionCode=10  
 
 *** Building for iOS ***
 

--- a/release-steps.txt
+++ b/release-steps.txt
@@ -13,12 +13,11 @@
 
   First, make sure the iOS/Android native sdk version has been updated. 
 
-  Then, run the follow command to bump the wrapper sdk version:
-    bash ./scripts/bump-wrapper-sdk-version.sh --oldWrapperSdkVersion=<old_version> --newWrapperSdkVersion=<new_version> --oldAndroidVersionCode=<old_version> --newAndroidVersionCode=<new_version>
+  Then, from the root folder, run the follow command to bump the wrapper sdk version:
+    bash ./scripts/bump-wrapper-sdk-version.sh --newWrapperSdkVersion=<new_version>
   
-  Note that "oldWrapperSdkVersion" is the latest version of Mobile Center React Native SDK that we release (https://github.com/Microsoft/mobile-center-sdk-react-native/releases),
-  and "oldAndroidVersionCode" is "versionCode" in the ./mobile-center/android/build.gradle file. For example, when we want to release v0.8.2 of this SDK, the bash command to run should be:
-    bash ./scripts/bump-wrapper-sdk-version.sh --oldWrapperSdkVersion=0.8.1 --newWrapperSdkVersion=0.8.2 --oldAndroidVersionCode=9 --newAndroidVersionCode=10  
+  For example, when we want to release v0.8.2 of this SDK, the bash command to run should be:
+    bash ./scripts/bump-wrapper-sdk-version.sh --newWrapperSdkVersion=0.8.2
 
 *** Building for iOS ***
 

--- a/release-steps.txt
+++ b/release-steps.txt
@@ -13,7 +13,7 @@
 
   First, make sure the iOS/Android native sdk version has been updated. 
 
-  Then, from the root folder, run the follow command to bump the wrapper sdk version:
+  Then, from the root folder, run the following command to bump the wrapper sdk version:
     bash ./scripts/bump-wrapper-sdk-version.sh --newWrapperSdkVersion=<new_version>
   
   For example, when we want to release v0.8.2 of this SDK, the bash command to run should be:

--- a/release-steps.txt
+++ b/release-steps.txt
@@ -48,7 +48,7 @@
 
 *** Building for iOS ***
 
-- Download the latest Mobile Center frameworks zip from https://github.com/Microsoft/mobile-center-sdk-ios/releases.
+  - Download the latest Mobile Center frameworks zip from https://github.com/Microsoft/mobile-center-sdk-ios/releases.
   - Unzip it.
   - Open up RNMobileCenterShared/ios/RNMobileCenterShared.xcodeproj in Xcode
   - Drag in MobileCenter.framework; check "Copy items if needed"; Add to the RNMobileCenterShared target
@@ -76,14 +76,16 @@
   - Publish the release; it will tag the source, so ideally try to make sure it's matched to the binary
 
   To publish the updated CocoaPod:
-  - cd mobile-center-sdk-react-native
+  - cd mobile-center-sdk-react-native/RNMobileCenterShared/Products
   - Ensure you are a contributor to the CocoaPod; if you aren't, have the original contributor add your email address as a maintainer
   - Create a session (using your name and email, not joe blow):  pod trunk register joe.blow@microsoft.com 'Joe Blow' --description='macbook pro'
   - Click on the link in the email that arrives to complete creating the session
+  - As a sanity check, fetch the latest changes of pod repo:
+    pod repo update
   - Lint the update:
     pod spec lint RNMobileCenterShared.podspec  --allow-warnings
 
-    The only warning should be:  There was a problem validating the URL https://mobile.azure.com.
+    The only warning might be:  There was a problem validating the URL https://mobile.azure.com.
   - Publish the update:
     pod trunk push RNMobileCenterShared.podspec --allow-warnings
   - As a double check, ensure that everything looks OK with the published podspec here:  https://cocoapods.org/?q=RNMobileCenter

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+while [ "$1" != "" ]; do
+    PARAM=`echo $1 | awk -F= '{print $1}'`
+    VALUE=`echo $1 | awk -F= '{print $2}'`
+    case $PARAM in
+        --oldWrapperSdkVersion)
+            oldWrapperSdkVersion=$VALUE
+            ;;
+        --newWrapperSdkVersion)
+            newWrapperSdkVersion=$VALUE
+            ;;
+        --oldAndroidVersionCode)
+            oldAndroidVersionCode=$VALUE
+            ;;
+        --newAndroidVersionCode)
+            newAndroidVersionCode=$VALUE
+            ;;
+        *)
+    esac
+    shift
+done
+
+echo "React-Native SDK $oldWrapperSdkVersion will be updated to $newWrapperSdkVersion"
+echo "React-Native SDK Android VersionCode $oldAndroidVersionCode will be updated to $newAndroidVersionCode"
+
+# Update wrapper sdk version in package.json for mobile-center, mobile-center-crashes, mobile-center-analytics, 
+# mobile-center-push and mobile-center-link-script NPM packages
+
+export newVersion=$newWrapperSdkVersion
+cat ./mobile-center/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center/package.json
+cat ./mobile-center-crashes/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-crashes/package.json
+cat ./mobile-center-analytics/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-analytics/package.json
+cat ./mobile-center-push/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-push/package.json
+cat ./mobile-center-link-scripts/package.json | jq -r '.version = env.newVersion' > ./mobile-center-link-scripts/package.json
+
+# Update wrapperk sdk version and android VersionCode in Android build.gradle for mobile-center, mobile-center-crashes, mobile-center-analytics,
+# mobile-center-push and RNMobileCenterShared projects
+
+gradleFileContent="$(cat ./mobile-center/android/build.gradle)"
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center/android/build.gradle
+
+gradleFileContent="$(cat ./mobile-center-crashes/android/build.gradle)"
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center-crashes/android/build.gradle
+
+gradleFileContent="$(cat ./mobile-center-analytics/android/build.gradle)"
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center-analytics/android/build.gradle
+
+gradleFileContent="$(cat ./mobile-center-push/android/build.gradle)"
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center-push/android/build.gradle
+
+gradleFileContent="$(cat ./RNMobileCenterShared/android/build.gradle)"
+gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./RNMobileCenterShared/android/build.gradle
+
+# Update wrapper sdk version in postlink.js for mobile-center, mobile-center-crashes, mobile-center-analytics,
+# and mobile-center-push
+postlinkFileContent="$(cat ./mobile-center/scripts/postlink.js)"
+echo "${postlinkFileContent/$oldWrapperSdkVersion/$newWrapperSdkVersion}" > ./mobile-center/scripts/postlink.js
+
+postlinkFileContent="$(cat ./mobile-center-crashes/scripts/postlink.js)"
+echo "${postlinkFileContent/$oldWrapperSdkVersion/$newWrapperSdkVersion}" > ./mobile-center-crashes/scripts/postlink.js
+
+postlinkFileContent="$(cat ./mobile-center-analytics/scripts/postlink.js)"
+echo "${postlinkFileContent/$oldWrapperSdkVersion/$newWrapperSdkVersion}" > ./mobile-center-analytics/scripts/postlink.js
+
+postlinkFileContent="$(cat ./mobile-center-push/scripts/postlink.js)"
+echo "${postlinkFileContent/$oldWrapperSdkVersion/$newWrapperSdkVersion}" > ./mobile-center-push/scripts/postlink.js
+
+# Update wrapper sdk version in RNMobileCenterShared/Products/RNMobileCenterShared.podspec
+podspecFileContent="$(cat ./RNMobileCenterShared/Products/RNMobileCenterShared.podspec)"
+echo "${podspecFileContent/$oldWrapperSdkVersion/$newWrapperSdkVersion}" > ./RNMobileCenterShared/Products/RNMobileCenterShared.podspec
+
+# Update wrapper sdk version in RNMobileCenterShared/ios/RNMobileCenterShared/RNMobileCenterShared.m
+fileContent="$(cat ./RNMobileCenterShared/ios/RNMobileCenterShared/RNMobileCenterShared.m)"
+echo "${fileContent/$oldWrapperSdkVersion/$newWrapperSdkVersion}" > ./RNMobileCenterShared/ios/RNMobileCenterShared/RNMobileCenterShared.m
+
+echo "done."

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -33,7 +33,7 @@ cat ./mobile-center/package.json | jq -r '.version = env.newVersion' | jq -r '.d
 cat ./mobile-center-crashes/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-crashes/package.json.temp && mv ./mobile-center-crashes/package.json.temp ./mobile-center-crashes/package.json 
 cat ./mobile-center-analytics/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-analytics/package.json.temp && mv ./mobile-center-analytics/package.json.temp ./mobile-center-analytics/package.json
 cat ./mobile-center-push/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-push/package.json.temp && mv ./mobile-center-push/package.json.temp ./mobile-center-push/package.json
-cat ./mobile-center-link-scripts/package.json | jq -r '.version = env.newVersion' > ./mobile-center-link-scripts/package.json.temp && mv ./mobile-center-link-scripts/package.json./temp ./mobile-center-link-scripts/package.json
+cat ./mobile-center-link-scripts/package.json | jq -r '.version = env.newVersion' > ./mobile-center-link-scripts/package.json.temp && mv ./mobile-center-link-scripts/package.json.temp ./mobile-center-link-scripts/package.json
 
 # Update wrapperk sdk version and android VersionCode in Android build.gradle for mobile-center, mobile-center-crashes, mobile-center-analytics,
 # mobile-center-push and RNMobileCenterShared projects

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Bump version of Mobile Center React Native SDK for release
 
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
@@ -28,11 +29,11 @@ echo "React-Native SDK Android VersionCode $oldAndroidVersionCode will be update
 # mobile-center-push and mobile-center-link-script NPM packages
 
 export newVersion=$newWrapperSdkVersion
-cat ./mobile-center/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center/package.json
-cat ./mobile-center-crashes/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-crashes/package.json
-cat ./mobile-center-analytics/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-analytics/package.json
-cat ./mobile-center-push/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-push/package.json
-cat ./mobile-center-link-scripts/package.json | jq -r '.version = env.newVersion' > ./mobile-center-link-scripts/package.json
+cat ./mobile-center/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center/package.json.temp && mv ./mobile-center/package.json.temp ./mobile-center/package.json
+cat ./mobile-center-crashes/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-crashes/package.json.temp && mv ./mobile-center-crashes/package.json.temp ./mobile-center-crashes/package.json 
+cat ./mobile-center-analytics/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-analytics/package.json.temp && mv ./mobile-center-analytics/package.json.temp ./mobile-center-analytics/package.json
+cat ./mobile-center-push/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-push/package.json.temp && mv ./mobile-center-push/package.json.temp ./mobile-center-push/package.json
+cat ./mobile-center-link-scripts/package.json | jq -r '.version = env.newVersion' > ./mobile-center-link-scripts/package.json.temp && mv ./mobile-center-link-scripts/package.json./temp ./mobile-center-link-scripts/package.json
 
 # Update wrapperk sdk version and android VersionCode in Android build.gradle for mobile-center, mobile-center-crashes, mobile-center-analytics,
 # mobile-center-push and RNMobileCenterShared projects

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -5,30 +5,36 @@ while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
     VALUE=`echo $1 | awk -F= '{print $2}'`
     case $PARAM in
-        --oldWrapperSdkVersion)
-            oldWrapperSdkVersion=$VALUE
-            ;;
         --newWrapperSdkVersion)
             newWrapperSdkVersion=$VALUE
-            ;;
-        --oldAndroidVersionCode)
-            oldAndroidVersionCode=$VALUE
-            ;;
-        --newAndroidVersionCode)
-            newAndroidVersionCode=$VALUE
             ;;
         *)
     esac
     shift
 done
 
+# Exit if newWrapperSdkVersion has not been set
+if [ -z $newWrapperSdkVersion ]; then
+    echo "--newWrapperSdkVersion cannot be empty. Please pass in new sdk version as parameter."
+    exit 1
+fi
+
+# Find out the old wrapper sdk version
+oldWrapperSdkVersionString=$(grep versionName ./mobile-center/android/build.gradle)
+[[ ${oldWrapperSdkVersionString} =~ ([0-9]+.[0-9]+.[0-9]+) ]]
+oldWrapperSdkVersion="${BASH_REMATCH[1]}"
+
+# Find out the old Android versionCode
+oldAndroidVersionCodeString=$(grep versionCode ./mobile-center/android/build.gradle)
+[[ ${oldAndroidVersionCodeString} =~ ([0-9]+) ]]
+oldAndroidVersionCode="${BASH_REMATCH[1]}"
+
+# Compute the new Android versionCode by adding one to old Android versionCode
+newAndroidVersionCode=$(($oldAndroidVersionCode + 1))
+
 # Exit if any of the parameters have not been set
 if [ -z $oldWrapperSdkVersion ]; then
     echo "oldWrapperSdkVersion cannot be empty"
-    exit 1
-fi
-if [ -z $newWrapperSdkVersion ]; then
-    echo "newWrapperSdkVersion cannot be empty"
     exit 1
 fi
 if [ -z $oldAndroidVersionCode ]; then

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -22,6 +22,24 @@ while [ "$1" != "" ]; do
     shift
 done
 
+# Exit if any of the parameters have not been set
+if [ -z $oldWrapperSdkVersion ]; then
+    echo "oldWrapperSdkVersion cannot be empty"
+    exit 1
+fi
+if [ -z $newWrapperSdkVersion ]; then
+    echo "newWrapperSdkVersion cannot be empty"
+    exit 1
+fi
+if [ -z $oldAndroidVersionCode ]; then
+    echo "oldAndroidVersionCode cannot be empty"
+    exit 1
+fi
+if [ -z $newAndroidVersionCode ]; then
+    echo "newAndroidVersionCode cannot be empty"
+    exit 1
+fi
+
 echo "React-Native SDK $oldWrapperSdkVersion will be updated to $newWrapperSdkVersion"
 echo "React-Native SDK Android VersionCode $oldAndroidVersionCode will be updated to $newAndroidVersionCode"
 

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -30,9 +30,9 @@ echo "React-Native SDK Android VersionCode $oldAndroidVersionCode will be update
 
 export newVersion=$newWrapperSdkVersion
 cat ./mobile-center/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center/package.json.temp && mv ./mobile-center/package.json.temp ./mobile-center/package.json
-cat ./mobile-center-crashes/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-crashes/package.json.temp && mv ./mobile-center-crashes/package.json.temp ./mobile-center-crashes/package.json 
-cat ./mobile-center-analytics/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-analytics/package.json.temp && mv ./mobile-center-analytics/package.json.temp ./mobile-center-analytics/package.json
-cat ./mobile-center-push/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center-link-scripts" = env.newVersion' > ./mobile-center-push/package.json.temp && mv ./mobile-center-push/package.json.temp ./mobile-center-push/package.json
+cat ./mobile-center-crashes/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center" = env.newVersion' > ./mobile-center-crashes/package.json.temp && mv ./mobile-center-crashes/package.json.temp ./mobile-center-crashes/package.json 
+cat ./mobile-center-analytics/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center" = env.newVersion' > ./mobile-center-analytics/package.json.temp && mv ./mobile-center-analytics/package.json.temp ./mobile-center-analytics/package.json
+cat ./mobile-center-push/package.json | jq -r '.version = env.newVersion' | jq -r '.dependencies."mobile-center" = env.newVersion' > ./mobile-center-push/package.json.temp && mv ./mobile-center-push/package.json.temp ./mobile-center-push/package.json
 cat ./mobile-center-link-scripts/package.json | jq -r '.version = env.newVersion' > ./mobile-center-link-scripts/package.json.temp && mv ./mobile-center-link-scripts/package.json.temp ./mobile-center-link-scripts/package.json
 
 # Update wrapperk sdk version and android VersionCode in Android build.gradle for mobile-center, mobile-center-crashes, mobile-center-analytics,


### PR DESCRIPTION
bump-wrapper-sdk-version.sh script can be run locally, not yet ready for Bitrise. We can modify this script to allow it run on Bitrise if we want to automate this process, though I doubt we'll ever get this process fully automated.