### PR TITLE
support ios only or android only project

### DIFF
--- a/mobile-center-analytics/scripts/postlink.js
+++ b/mobile-center-analytics/scripts/postlink.js
@@ -5,7 +5,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
     rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
-            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
             return Promise.reject();
         });
     })
@@ -14,7 +14,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
     prompt.message = prompt.message.replace(/Android/, 'iOS');
     return rnpmlink.inquirer.prompt(prompt)
         .catch((e) => {
-            console.log(`Could not find answer of whenToEnableAnalytics. Error Reason - ${e.message}`);
+            console.log(`Could not determine when to enable Mobile Center analytics. Error Reason - ${e.message}`);
             return Promise.reject();
         });
     })

--- a/mobile-center-analytics/scripts/postlink.js
+++ b/mobile-center-analytics/scripts/postlink.js
@@ -3,20 +3,22 @@ const npmPackages = require('./../package.json');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
-    return initMobileCenterConfig()
+    rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
             console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then(() => {
+    })
+.then(() => {
     const prompt = npmPackages.rnpm.params[0];
     prompt.message = prompt.message.replace(/Android/, 'iOS');
     return rnpmlink.inquirer.prompt(prompt)
         .catch((e) => {
             console.log(`Could not find answer of whenToEnableAnalytics. Error Reason - ${e.message}`);
-            return Promise.reject();   
-        });     
-}).then((answer) => {
+            return Promise.reject();
+        });
+    })
+.then((answer) => {
     const code = answer.whenToEnableAnalytics === 'ALWAYS_SEND' ?
         '  [RNAnalytics registerWithInitiallyEnabled:true];  // Initialize Mobile Center analytics' :
         '  [RNAnalytics registerWithInitiallyEnabled:false];  // Initialize Mobile Center analytics';
@@ -25,7 +27,8 @@ return rnpmlink.ios.checkIfAppDelegateExists()
             console.log(`Could not initialize Mobile Center analytics in AppDelegate. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then((file) => {
+    })
+.then((file) => {
     console.log(`Added code to initialize iOS Analytics SDK in ${file}`);
     return rnpmlink.ios.addPodDeps([
         { pod: 'MobileCenter/Analytics', version: '0.12.1' },
@@ -39,4 +42,5 @@ return rnpmlink.ios.checkIfAppDelegateExists()
         `);
         return Promise.reject();
     });
-}).catch(() => Promose.resolve());
+})
+.catch(() => Promise.resolve());

--- a/mobile-center-analytics/scripts/prelink.js
+++ b/mobile-center-analytics/scripts/prelink.js
@@ -2,4 +2,12 @@ const rnpmlink = require('mobile-center-link-scripts');
 
 console.log('Configuring Mobile Center Analytics');
 
-return rnpmlink.android.initMobileCenterConfig(false);
+return rnpmlink.android.checkIfAndroidDirectoryExists()
+.then(() => {
+    rnpmlink.android.initMobileCenterConfig()
+        .catch((e) => {
+            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
+    })
+.catch(() => Promise.resolve());

--- a/mobile-center-crashes/scripts/postlink.js
+++ b/mobile-center-crashes/scripts/postlink.js
@@ -1,16 +1,30 @@
 const rnpmlink = require('mobile-center-link-scripts');
 const npmPackages = require('./../package.json');
 
-return rnpmlink.ios.initMobileCenterConfig().then(() => {
+return rnpmlink.ios.checkIfAppDelegateExists()
+.then(() => {
+    return initMobileCenterConfig()
+        .catch((e) => {
+            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
+}).then(() => {
     const prompt = npmPackages.rnpm.params[0];
     prompt.message = prompt.message.replace(/Android/, 'iOS');
-
-    return rnpmlink.inquirer.prompt(prompt);
+    return rnpmlink.inquirer.prompt(prompt)
+        .catch((e) => {
+            console.log(`Could not find answer of whenToSendCrashes. Error Reason - ${e.message}`);
+            return Promise.reject();   
+        });     
 }).then((answer) => {
     const code = answer.whenToSendCrashes === 'ALWAYS_SEND' ?
-        '  [RNCrashes registerWithCrashDelegate: [[RNCrashesDelegateAlwaysSend alloc] init]];  // Initialize Mobile Center crashes' :
-        '  [RNCrashes register];  // Initialize Mobile Center crashes';
-    return rnpmlink.ios.initInAppDelegate('#import <RNCrashes/RNCrashes.h>', code, /.*\[RNCrashes register.*/g);
+    '  [RNCrashes registerWithCrashDelegate: [[RNCrashesDelegateAlwaysSend alloc] init]];  // Initialize Mobile Center crashes' :
+    '  [RNCrashes register];  // Initialize Mobile Center crashes';
+return rnpmlink.ios.initInAppDelegate('#import <RNCrashes/RNCrashes.h>', code, /.*\[RNCrashes register.*/g)
+        .catch((e) => {
+            console.log(`Could not initialize Mobile Center crashes in AppDelegate. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
 }).then((file) => {
     console.log(`Added code to initialize iOS Crashes SDK in ${file}`);
     return rnpmlink.ios.addPodDeps([
@@ -23,6 +37,6 @@ return rnpmlink.ios.initMobileCenterConfig().then(() => {
 
             Error Reason - ${e.message}
         `);
-        return Promise.resolve();
+        return Promise.reject();
     });
-});
+}).catch(() => Promose.resolve());

--- a/mobile-center-crashes/scripts/postlink.js
+++ b/mobile-center-crashes/scripts/postlink.js
@@ -3,29 +3,32 @@ const npmPackages = require('./../package.json');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
-    return initMobileCenterConfig()
+    rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
             console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then(() => {
+    })
+.then(() => {
     const prompt = npmPackages.rnpm.params[0];
     prompt.message = prompt.message.replace(/Android/, 'iOS');
     return rnpmlink.inquirer.prompt(prompt)
         .catch((e) => {
             console.log(`Could not find answer of whenToSendCrashes. Error Reason - ${e.message}`);
-            return Promise.reject();   
-        });     
-}).then((answer) => {
+            return Promise.reject();
+        });
+    })
+.then((answer) => {
     const code = answer.whenToSendCrashes === 'ALWAYS_SEND' ?
     '  [RNCrashes registerWithCrashDelegate: [[RNCrashesDelegateAlwaysSend alloc] init]];  // Initialize Mobile Center crashes' :
     '  [RNCrashes register];  // Initialize Mobile Center crashes';
-return rnpmlink.ios.initInAppDelegate('#import <RNCrashes/RNCrashes.h>', code, /.*\[RNCrashes register.*/g)
+    return rnpmlink.ios.initInAppDelegate('#import <RNCrashes/RNCrashes.h>', code, /.*\[RNCrashes register.*/g)
         .catch((e) => {
             console.log(`Could not initialize Mobile Center crashes in AppDelegate. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then((file) => {
+    })
+.then((file) => {
     console.log(`Added code to initialize iOS Crashes SDK in ${file}`);
     return rnpmlink.ios.addPodDeps([
         { pod: 'MobileCenter/Crashes', version: '0.12.1' },
@@ -39,4 +42,5 @@ return rnpmlink.ios.initInAppDelegate('#import <RNCrashes/RNCrashes.h>', code, /
         `);
         return Promise.reject();
     });
-}).catch(() => Promose.resolve());
+})
+.catch(() => Promise.resolve());

--- a/mobile-center-crashes/scripts/postlink.js
+++ b/mobile-center-crashes/scripts/postlink.js
@@ -5,7 +5,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
     rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
-            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
             return Promise.reject();
         });
     })
@@ -14,7 +14,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
     prompt.message = prompt.message.replace(/Android/, 'iOS');
     return rnpmlink.inquirer.prompt(prompt)
         .catch((e) => {
-            console.log(`Could not find answer of whenToSendCrashes. Error Reason - ${e.message}`);
+            console.log(`Could not determine when to send Mobile Center crashes. Error Reason - ${e.message}`);
             return Promise.reject();
         });
     })

--- a/mobile-center-crashes/scripts/prelink.js
+++ b/mobile-center-crashes/scripts/prelink.js
@@ -2,4 +2,12 @@ const rnpmlink = require('mobile-center-link-scripts');
 
 console.log('Configuring Mobile Center Crashes');
 
-return rnpmlink.android.initMobileCenterConfig(false);
+return rnpmlink.android.checkIfAndroidDirectoryExists()
+.then(() => {
+    rnpmlink.android.initMobileCenterConfig()
+        .catch((e) => {
+            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
+    })
+.catch(() => Promise.resolve());

--- a/mobile-center-link-scripts/src/android/index.js
+++ b/mobile-center-link-scripts/src/android/index.js
@@ -2,9 +2,20 @@ var fs = require('fs');
 
 var glob = require('glob');
 var inquirer = require('inquirer');
+var debug = require('debug')('mobile-center-link:android:index');
 
 var MobileCenterConfig = require('./MobileCenterConfig');
 module.exports = {
+    checkIfAndroidDirectoryExists: function() {
+        try {
+            fs.statSync('./android').isDirectory();
+        } catch (e) {
+            debug(`Could not find android directory`);
+            return Promise.reject();
+        }
+        return Promise.resolve();
+    },
+
     initMobileCenterConfig: function (alwaysPromptForAppSecret) {
         var config = new MobileCenterConfig(MobileCenterConfig.searchForFile());
         var currentAppSecret = config.get('app_secret');

--- a/mobile-center-link-scripts/src/android/index.js
+++ b/mobile-center-link-scripts/src/android/index.js
@@ -8,12 +8,13 @@ var MobileCenterConfig = require('./MobileCenterConfig');
 module.exports = {
     checkIfAndroidDirectoryExists: function() {
         try {
-            fs.statSync('./android').isDirectory();
+            if (fs.statSync('./android').isDirectory()) {
+                return Promise.resolve();
+            }
         } catch (e) {
-            debug(`Could not find android directory`);
-            return Promise.reject();
+            debug('Could not find /android directory in your application.');
         }
-        return Promise.resolve();
+        return Promise.reject();
     },
 
     initMobileCenterConfig: function (alwaysPromptForAppSecret) {

--- a/mobile-center-link-scripts/src/ios/index.js
+++ b/mobile-center-link-scripts/src/ios/index.js
@@ -25,6 +25,7 @@ module.exports = {
             debug(`Could not find AppDelegate.m file at ${appDelegatePath}, so could not add the framework for iOS.`);
             return Promise.reject();
         }
+        return Promise.resolve();
     },
 
     initMobileCenterConfig: function() {

--- a/mobile-center-link-scripts/src/ios/index.js
+++ b/mobile-center-link-scripts/src/ios/index.js
@@ -17,17 +17,16 @@ var appDelegatePaths = glob.sync("**/AppDelegate.m", { ignore: "node_modules/**"
 var appDelegatePath = findFileByAppName(appDelegatePaths, pjson ? pjson.name : null) || appDelegatePaths[0];
 debug('AppDelegate.m path - ' + appDelegatePath);
 
-try {
-    fs.accessSync(appDelegatePath, fs.F_OK);
-} catch (e) {
-    debug('Could not fine AppDelegate.m at ', appDelegatePath);
-    throw Error(`
-        Could not find AppDelegate.m file for this project, so could not add the framework for iOS.
-        You may have to add the framework manually.
-    `);
-}
-
 module.exports = {
+    checkIfAppDelegateExists: function() {
+        try {
+            fs.accessSync(appDelegatePath, fs.F_OK);
+        } catch (e) {
+            debug(`Could not find AppDelegate.m file at ${appDelegatePath}, so could not add the framework for iOS.`);
+            return Promise.reject();
+        }
+    },
+
     initMobileCenterConfig: function() {
         var config = new MobileCenterConfig(MobileCenterConfig.searchForFile(path.dirname(appDelegatePath)));
         var currentAppSecret = config.get('AppSecret');

--- a/mobile-center-push/scripts/postlink.js
+++ b/mobile-center-push/scripts/postlink.js
@@ -1,8 +1,19 @@
 const rnpmlink = require('mobile-center-link-scripts');
 
-return rnpmlink.ios.initMobileCenterConfig().then(() => {
+return rnpmlink.ios.checkIfAppDelegateExists()
+.then(() => {
+    return rnpmlink.ios.initMobileCenterConfig()
+        .catch((e) => {
+            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
+}).then(() => {
     const code = '  [RNPush register];  // Initialize Mobile Center push';
-    return rnpmlink.ios.initInAppDelegate('#import <RNPush/RNPush.h>', code);
+    return rnpmlink.ios.initInAppDelegate('#import <RNPush/RNPush.h>', code)
+        .catch((e) => {
+            console.log(`Could not initialize Mobile Center push in AppDelegate. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
 }).then((file) => {
     console.log(`Added code to initialize iOS Push SDK in ${file}`);
     return rnpmlink.ios.addPodDeps([
@@ -12,9 +23,8 @@ return rnpmlink.ios.initMobileCenterConfig().then(() => {
         console.log(`
             Could not install dependencies using CocoaPods.
             Please refer to the documentation to install dependencies manually.
-
             Error Reason - ${e.message}
         `);
-        return Promise.resolve();
+        return Promise.reject();
     });
-});
+}).catch(() => Promise.resolve());

--- a/mobile-center-push/scripts/postlink.js
+++ b/mobile-center-push/scripts/postlink.js
@@ -4,7 +4,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
     rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
-            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
             return Promise.reject();
         });
     })
@@ -25,6 +25,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
         console.log(`
             Could not install dependencies using CocoaPods.
             Please refer to the documentation to install dependencies manually.
+
             Error Reason - ${e.message}
         `);
         return Promise.reject();

--- a/mobile-center-push/scripts/postlink.js
+++ b/mobile-center-push/scripts/postlink.js
@@ -2,19 +2,21 @@ const rnpmlink = require('mobile-center-link-scripts');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
-    return rnpmlink.ios.initMobileCenterConfig()
+    rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
             console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then(() => {
+    })
+.then(() => {
     const code = '  [RNPush register];  // Initialize Mobile Center push';
     return rnpmlink.ios.initInAppDelegate('#import <RNPush/RNPush.h>', code)
         .catch((e) => {
             console.log(`Could not initialize Mobile Center push in AppDelegate. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then((file) => {
+    })
+.then((file) => {
     console.log(`Added code to initialize iOS Push SDK in ${file}`);
     return rnpmlink.ios.addPodDeps([
         { pod: 'MobileCenter/Push', version: '0.12.1' },
@@ -27,4 +29,5 @@ return rnpmlink.ios.checkIfAppDelegateExists()
         `);
         return Promise.reject();
     });
-}).catch(() => Promise.resolve());
+})
+.catch(() => Promise.resolve());

--- a/mobile-center-push/scripts/prelink.js
+++ b/mobile-center-push/scripts/prelink.js
@@ -2,4 +2,12 @@ const rnpmlink = require('mobile-center-link-scripts');
 
 console.log('Configuring Mobile Center Push');
 
-return rnpmlink.android.initMobileCenterConfig(false);
+return rnpmlink.android.checkIfAndroidDirectoryExists()
+.then(() => {
+    rnpmlink.android.initMobileCenterConfig(false)
+        .catch((e) => {
+            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
+    })
+.catch(() => Promise.resolve());

--- a/mobile-center-push/scripts/prelink.js
+++ b/mobile-center-push/scripts/prelink.js
@@ -4,7 +4,7 @@ console.log('Configuring Mobile Center Push');
 
 return rnpmlink.android.checkIfAndroidDirectoryExists()
 .then(() => {
-    rnpmlink.android.initMobileCenterConfig(false)
+    rnpmlink.android.initMobileCenterConfig()
         .catch((e) => {
             console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
             return Promise.reject();

--- a/mobile-center/scripts/postlink.js
+++ b/mobile-center/scripts/postlink.js
@@ -1,8 +1,19 @@
 const rnpmlink = require('mobile-center-link-scripts');
 
-return rnpmlink.ios.initMobileCenterConfig().then(() => {
+return rnpmlink.ios.checkIfAppDelegateExists()
+.then(() => {
+    return rnpmlink.ios.initMobileCenterConfig()
+        .catch((e) => {
+            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
+}).then(() => {
     const code = '  [RNMobileCenter register];  // Initialize Mobile Center ';
-    return rnpmlink.ios.initInAppDelegate('#import <RNMobileCenter/RNMobileCenter.h>', code);
+    return rnpmlink.ios.initInAppDelegate('#import <RNMobileCenter/RNMobileCenter.h>', code)
+        .catch((e) => {
+            console.log(`Could not initialize Mobile Center in AppDelegate. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
 }).then((file) => {
     console.log(`Added code to initialize iOS Mobile Center SDK in ${file}`);
     return rnpmlink.ios.addPodDeps([
@@ -11,9 +22,8 @@ return rnpmlink.ios.initMobileCenterConfig().then(() => {
         console.log(`
             Could not install dependencies using CocoaPods.
             Please refer to the documentation to install dependencies manually.
-
             Error Reason - ${e.message}
         `);
-        return Promise.resolve();
+        return Promise.reject();
     });
-});
+}).catch(() => Promise.resolve());

--- a/mobile-center/scripts/postlink.js
+++ b/mobile-center/scripts/postlink.js
@@ -2,19 +2,21 @@ const rnpmlink = require('mobile-center-link-scripts');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
-    return rnpmlink.ios.initMobileCenterConfig()
+    rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
             console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then(() => {
+    })
+.then(() => {
     const code = '  [RNMobileCenter register];  // Initialize Mobile Center ';
     return rnpmlink.ios.initInAppDelegate('#import <RNMobileCenter/RNMobileCenter.h>', code)
         .catch((e) => {
             console.log(`Could not initialize Mobile Center in AppDelegate. Error Reason - ${e.message}`);
             return Promise.reject();
         });
-}).then((file) => {
+    })
+.then((file) => {
     console.log(`Added code to initialize iOS Mobile Center SDK in ${file}`);
     return rnpmlink.ios.addPodDeps([
         { pod: 'RNMobileCenterShared', version: '0.9.0' }
@@ -26,4 +28,5 @@ return rnpmlink.ios.checkIfAppDelegateExists()
         `);
         return Promise.reject();
     });
-}).catch(() => Promise.resolve());
+})
+.catch(() => Promise.resolve());

--- a/mobile-center/scripts/postlink.js
+++ b/mobile-center/scripts/postlink.js
@@ -4,7 +4,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
 .then(() => {
     rnpmlink.ios.initMobileCenterConfig()
         .catch((e) => {
-            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
             return Promise.reject();
         });
     })
@@ -24,6 +24,7 @@ return rnpmlink.ios.checkIfAppDelegateExists()
         console.log(`
             Could not install dependencies using CocoaPods.
             Please refer to the documentation to install dependencies manually.
+
             Error Reason - ${e.message}
         `);
         return Promise.reject();

--- a/mobile-center/scripts/prelink.js
+++ b/mobile-center/scripts/prelink.js
@@ -2,4 +2,12 @@ const rnpmlink = require('mobile-center-link-scripts');
 
 console.log('Configuring Mobile Center');
 
-return rnpmlink.android.initMobileCenterConfig(true);
+return rnpmlink.android.checkIfAndroidDirectoryExists()
+.then(() => {
+    rnpmlink.android.initMobileCenterConfig()
+        .catch((e) => {
+            console.log(`Could not create mobile center config file. Error Reason - ${e.message}`);
+            return Promise.reject();
+        });
+    })
+.catch(() => Promise.resolve());


### PR DESCRIPTION
To address #104. 

Mobile Center react native sdk doesn't work well with `react-native link` if it's an android-only project or iOS-only project. The sdk assumes both projects exist and won't skip if one of them is missing.

This PR address this issue without changing other behaviors of `react-native link`. Also makes sure `react-native link` process won't be interrupted by any errors happened in the linking process.