### PR TITLE
Update TestApp and DemoApp to react native 0.48.3

### DIFF
--- a/DemoApp/package.json
+++ b/DemoApp/package.json
@@ -12,7 +12,7 @@
     "mobile-center-crashes": "0.9.0",
     "mobile-center-push": "0.9.0",
     "react": "16.0.0-alpha.12",
-    "react-native": "0.48.0",
+    "react-native": "0.48.3",
     "react-navigation": "^1.0.0-beta.11"
   },
   "devDependencies": {

--- a/TestApp/package.json
+++ b/TestApp/package.json
@@ -13,7 +13,7 @@
     "mobile-center-link-scripts": "../mobile-center-link-scripts",
     "mobile-center-push": "../mobile-center-push",
     "react": "16.0.0-alpha.12",
-    "react-native": "0.48.0",
+    "react-native": "0.48.3",
     "react-navigation": "^1.0.0-beta.11"
   },
   "devDependencies": {


### PR DESCRIPTION
[A bug in react native 0.48.0](https://github.com/facebook/react-native/issues/15768) caused our apps crashing on launching in Debug mode (not Release mode). It impacts both CLI (`react-native run-ios`) and Xcode environment. The bug is [fixed in 0.48.1](https://github.com/facebook/react-native/issues/15768#issuecomment-326901292). Bring it to the latest stable version 0.48.3.