### PR TITLE
Fix a bug in setCustomProperties where boolean property is always set to true

### DIFF
--- a/TestApp/MobileCenterScreen.js
+++ b/TestApp/MobileCenterScreen.js
@@ -75,6 +75,7 @@ export default class MobileCenterScreen extends React.Component {
       .clear('old')
       .set('color', 'blue')
       .set('optin', true)
+      .set('optout', false)
       .set('score', 7)
       .set('now', new Date());
     await MobileCenter.setCustomProperties(properties);

--- a/mobile-center/ios/RNMobileCenter/RNMobileCenter.m
+++ b/mobile-center/ios/RNMobileCenter/RNMobileCenter.m
@@ -85,7 +85,8 @@ RCT_EXPORT_METHOD(setCustomProperties:(NSDictionary*)properties
                     [customProperties setNumber:value forKey:key];
                 }
                 else if ([typeString isEqualToString:@"boolean"]) {
-                    [customProperties setBool:value forKey:key];
+                    NSNumber *num = value;
+                    [customProperties setBool:[num boolValue] forKey:key];
                 }
                 else if ([typeString isEqualToString:@"date-time"]) {
                     NSDate *date = [RCTConvert NSDate:value];


### PR DESCRIPTION
The issue is that RN iOS setCustomProperties() API always set boolean properties to `true` regardless of the value. The problem is with iOS RNMobileCenter.m implementation that we're not casting `id` type into `BOOL` type properly. The fix is to make type conversion properly.