### PR TITLE
Fix a bug where Analytics is always enabled even Analytics is set to "Enable in JavaScript"

### DIFF
--- a/mobile-center-analytics/android/src/main/java/com/microsoft/azure/mobile/react/analytics/RNAnalyticsModule.java
+++ b/mobile-center-analytics/android/src/main/java/com/microsoft/azure/mobile/react/analytics/RNAnalyticsModule.java
@@ -18,11 +18,11 @@ public class RNAnalyticsModule extends BaseJavaModule {
 
     public RNAnalyticsModule(Application application, boolean startEnabled) {
         RNMobileCenterShared.configureMobileCenter(application);
-        //Analytics.setAutoPageTrackingEnabled(false); // TODO: once the underlying SDK supports this, make sure to call this
         MobileCenter.start(Analytics.class);
         if (!startEnabled) {
             Analytics.setEnabled(false);
         }
+        //Analytics.setAutoPageTrackingEnabled(false); // TODO: once the underlying SDK supports this, make sure to call this
     }
 
     @Override

--- a/mobile-center-analytics/android/src/main/java/com/microsoft/azure/mobile/react/analytics/RNAnalyticsModule.java
+++ b/mobile-center-analytics/android/src/main/java/com/microsoft/azure/mobile/react/analytics/RNAnalyticsModule.java
@@ -18,14 +18,11 @@ public class RNAnalyticsModule extends BaseJavaModule {
 
     public RNAnalyticsModule(Application application, boolean startEnabled) {
         RNMobileCenterShared.configureMobileCenter(application);
-        if (!startEnabled) {
-            // Avoid starting an analytics session.
-            // Note that we don't call this if startEnabled is true, because
-            // that causes a session to try and start before Analytics is started.
-            Analytics.setEnabled(false);
-        }
         //Analytics.setAutoPageTrackingEnabled(false); // TODO: once the underlying SDK supports this, make sure to call this
         MobileCenter.start(Analytics.class);
+        if (!startEnabled) {
+            Analytics.setEnabled(false);
+        }
     }
 
     @Override

--- a/mobile-center-analytics/ios/RNAnalytics/RNAnalytics.m
+++ b/mobile-center-analytics/ios/RNAnalytics/RNAnalytics.m
@@ -31,14 +31,11 @@ RCT_EXPORT_MODULE();
 + (void)registerWithInitiallyEnabled:(BOOL) enabled
 {
     [RNMobileCenterShared configureMobileCenter];
-    if (!enabled) {
-        // Avoid starting an analytics session.
-        // Note that we don't call this if startEnabled is true, because
-        // that causes a session to try and start before MSAnalytics is started.
-        [MSAnalytics setEnabled:enabled];
-    }
     //[MSAnalytics setAutoPageTrackingEnabled:false]; // TODO: once the underlying SDK supports this, make sure to call this
     [MSMobileCenter startService:[MSAnalytics class]];
+    if (!enabled) {
+        [MSAnalytics setEnabled:enabled];
+    }
 }
 
 RCT_EXPORT_METHOD(isEnabled:(RCTPromiseResolveBlock)resolve

--- a/mobile-center-analytics/ios/RNAnalytics/RNAnalytics.m
+++ b/mobile-center-analytics/ios/RNAnalytics/RNAnalytics.m
@@ -31,11 +31,11 @@ RCT_EXPORT_MODULE();
 + (void)registerWithInitiallyEnabled:(BOOL) enabled
 {
     [RNMobileCenterShared configureMobileCenter];
-    //[MSAnalytics setAutoPageTrackingEnabled:false]; // TODO: once the underlying SDK supports this, make sure to call this
     [MSMobileCenter startService:[MSAnalytics class]];
     if (!enabled) {
         [MSAnalytics setEnabled:enabled];
     }
+    //[MSAnalytics setAutoPageTrackingEnabled:false]; // TODO: once the underlying SDK supports this, make sure to call this
 }
 
 RCT_EXPORT_METHOD(isEnabled:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
Issue: When Analytics is set to "Enable in JavaScript" in the following question in `react-native link`:
```
For the [platform] app, should user tracking be enabled automatically ? (Use arrow keys)
          Enable Automatically
        > Enable in JavaScript
```
Analytics is supposed to remain disabled until `await Analytics.setEnabled(true);` called in JavaScript code. But Analytics is not disabled in this case. This issue exists in both iOS and Android. It is not affecting other services (e.g. Crashes service).

Root cause: `Analytics.setEnabled(false);` should not be called before Analytics service is started. 

Fix: Start Analytics before calling `.setEnabled(false)`.