### PR TITLE
Fix ios linking issue

### DIFF
--- a/mobile-center-analytics/scripts/postlink.js
+++ b/mobile-center-analytics/scripts/postlink.js
@@ -2,13 +2,10 @@ const rnpmlink = require('mobile-center-link-scripts');
 const npmPackages = require('./../package.json');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
-    .then(() => {
-        rnpmlink.ios.initMobileCenterConfig()
-            .catch((e) => {
-                console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
-                return Promise.reject();
-            });
-    })
+    .then(() => rnpmlink.ios.initMobileCenterConfig().catch((e) => {
+        console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
+        return Promise.reject();
+    }))
     .then(() => {
         const prompt = npmPackages.rnpm.params[0];
         prompt.message = prompt.message.replace(/Android/, 'iOS');

--- a/mobile-center-crashes/scripts/postlink.js
+++ b/mobile-center-crashes/scripts/postlink.js
@@ -2,13 +2,10 @@ const rnpmlink = require('mobile-center-link-scripts');
 const npmPackages = require('./../package.json');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
-    .then(() => {
-        rnpmlink.ios.initMobileCenterConfig()
-            .catch((e) => {
-                console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
-                return Promise.reject();
-            });
-    })
+    .then(() => rnpmlink.ios.initMobileCenterConfig().catch((e) => {
+        console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
+        return Promise.reject();
+    }))
     .then(() => {
         const prompt = npmPackages.rnpm.params[0];
         prompt.message = prompt.message.replace(/Android/, 'iOS');

--- a/mobile-center-link-scripts/src/ios/index.js
+++ b/mobile-center-link-scripts/src/ios/index.js
@@ -65,7 +65,7 @@ module.exports = {
             const appDelegate = new AppDelegate(appDelegatePath);
             appDelegate.addHeader(header);
             appDelegate.addInitCode(initCode, oldInitCodeRegExp);
-            return appDelegate.save();
+            return Promise.resolve(appDelegate.save());
         } catch (e) {
             debug('Could not change AppDelegate', e);
             return Promise.reject(e);

--- a/mobile-center-push/scripts/postlink.js
+++ b/mobile-center-push/scripts/postlink.js
@@ -1,13 +1,10 @@
 const rnpmlink = require('mobile-center-link-scripts');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
-    .then(() => {
-        rnpmlink.ios.initMobileCenterConfig()
-            .catch((e) => {
-                console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
-                return Promise.reject();
-            });
-    })
+    .then(() => rnpmlink.ios.initMobileCenterConfig().catch((e) => {
+        console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
+        return Promise.reject();
+    }))
     .then(() => {
         const code = '  [RNPush register];  // Initialize Mobile Center push';
         return rnpmlink.ios.initInAppDelegate('#import <RNPush/RNPush.h>', code)

--- a/mobile-center/scripts/postlink.js
+++ b/mobile-center/scripts/postlink.js
@@ -1,13 +1,10 @@
 const rnpmlink = require('mobile-center-link-scripts');
 
 return rnpmlink.ios.checkIfAppDelegateExists()
-    .then(() => {
-        rnpmlink.ios.initMobileCenterConfig()
-            .catch((e) => {
-                console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
-                return Promise.reject();
-            });
-    })
+    .then(() => rnpmlink.ios.initMobileCenterConfig().catch((e) => {
+        console.log(`Could not create or update Mobile Center config file (MobileCenter-Config.plist). Error Reason - ${e.message}`);
+        return Promise.reject();
+    }))
     .then(() => {
         const code = '  [RNMobileCenter register];  // Initialize Mobile Center ';
         return rnpmlink.ios.initInAppDelegate('#import <RNMobileCenter/RNMobileCenter.h>', code)


### PR DESCRIPTION
`react-native link` is broken for iOS projects due to #107. 

There are two issues with #107:
(1)  `initInAppDelegate(header, initCode, oldInitCodeRegExp)` in /mobile-center-link-scripts/src/ios/index.js has inconsistent return types. It returns a string in success but a Promise in failure. This caused a runtime error when calling `initInAppDelegate` in `react-native link` on iOS project.
(2) postlink.js in mobile-center is missing a `return` in the arrow function ([this line](https://github.com/Microsoft/mobile-center-sdk-react-native/blob/develop/mobile-center/scripts/postlink.js#L5)) in the promise chaining. This caused `react-native link` prompting user for iOS appsecret without waiting for user input. This issue exists for mobile-center-analytics, mobile-center-push, mobile-center-crashes module.

This PR addresses the above issues and tested on blank new RN apps (iOS & Android).