### PR TITLE
Fix/bump wrapper sdk script issue

### DIFF
--- a/scripts/bump-android-sdk-version.sh
+++ b/scripts/bump-android-sdk-version.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Update Mobile Center React Native SDK to reference a new version of Mobile Center Android SDK
 
+set -e
+
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
     VALUE=`echo $1 | awk -F= '{print $2}'`
     case $PARAM in
         --newAndroidSdkVersion)
-            newAndroidSdkVersion=$VALUE
-            ;;
+            newAndroidSdkVersion=$VALUE ;;
         *)
     esac
     shift

--- a/scripts/bump-ios-sdk-version.sh
+++ b/scripts/bump-ios-sdk-version.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Update Mobile Center React Native SDK to reference a new version of Mobile Center iOS SDK
 
+set -e
+
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
     VALUE=`echo $1 | awk -F= '{print $2}'`
     case $PARAM in
         --newiOSSdkVersion)
-            newiOSSdkVersion=$VALUE
-            ;;
+            newiOSSdkVersion=$VALUE ;;
         *)
     esac
     shift

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -70,14 +70,17 @@ echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAnd
 
 gradleFileContent="$(cat ./mobile-center-crashes/android/build.gradle)"
 gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/com.microsoft.azure.mobile.react\:mobile-center-react-native\:$oldWrapperSdkVersion/com.microsoft.azure.mobile.react:mobile-center-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center-crashes/android/build.gradle
 
 gradleFileContent="$(cat ./mobile-center-analytics/android/build.gradle)"
 gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/com.microsoft.azure.mobile.react\:mobile-center-react-native\:$oldWrapperSdkVersion/com.microsoft.azure.mobile.react:mobile-center-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center-analytics/android/build.gradle
 
 gradleFileContent="$(cat ./mobile-center-push/android/build.gradle)"
 gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/com.microsoft.azure.mobile.react\:mobile-center-react-native\:$oldWrapperSdkVersion/com.microsoft.azure.mobile.react:mobile-center-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center-push/android/build.gradle
 
 gradleFileContent="$(cat ./RNMobileCenterShared/android/build.gradle)"

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Bump version of Mobile Center React Native SDK for release
 
+set -e
+
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
     VALUE=`echo $1 | awk -F= '{print $2}'`
     case $PARAM in
         --newWrapperSdkVersion)
-            newWrapperSdkVersion=$VALUE
-            ;;
+            newWrapperSdkVersion=$VALUE ;;
         *)
     esac
     shift

--- a/scripts/bump-wrapper-sdk-version.sh
+++ b/scripts/bump-wrapper-sdk-version.sh
@@ -64,6 +64,7 @@ cat ./mobile-center-link-scripts/package.json | jq -r '.version = env.newVersion
 
 gradleFileContent="$(cat ./mobile-center/android/build.gradle)"
 gradleFileContent=`echo "${gradleFileContent/versionName \"$oldWrapperSdkVersion\"/versionName \"$newWrapperSdkVersion\"}"`
+gradleFileContent=`echo "${gradleFileContent/com.microsoft.azure.mobile.react\:mobile-center-react-native\:$oldWrapperSdkVersion/com.microsoft.azure.mobile.react:mobile-center-react-native:$newWrapperSdkVersion}"`
 echo "${gradleFileContent/versionCode $oldAndroidVersionCode/versionCode $newAndroidVersionCode}" > ./mobile-center/android/build.gradle
 
 gradleFileContent="$(cat ./mobile-center-crashes/android/build.gradle)"


### PR DESCRIPTION
bump-wrapper-sdk-version.sh needs to bump **mobile-center-react-native** jcenter package in build.gradle files as well.

For example: `compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.9.1'` => `compile 'com.microsoft.azure.mobile.react:mobile-center-react-native:0.9.2'`